### PR TITLE
Set parameters and trigger in AWS (Main <= aws)

### DIFF
--- a/milestone.txt
+++ b/milestone.txt
@@ -6,7 +6,7 @@ register secret tokens [v]
   * access_token_key=[access token],
   * access_token_secret=[access token secret])
 
-add cloudwatch trigger
+add cloudwatch trigger => using Amazon EventBridge
 
 
 code


### PR DESCRIPTION
## Set Parameters And a Trigger in AWS

### Set Parameters AWS System Manager Parameter Store by Using KMS Key
There were two options, Secrets Manager and Parameter Store.
Parameters are rarely changed and do not need to be dynamic, so I chose Parameter Store.
- Parameters
  - nag-access-token
  - nag-access-token-secret
  - nag-consumer-key
  - nag-consumer-key-secret
  
### Trigger by AWS EventBridge
AWS EventBridge will execute the project every day at 2 am.
This is simple and free. That is why I chose it instead of CloudWatch.